### PR TITLE
2927: Setup primary prometheus fed

### DIFF
--- a/prometheus.yaml
+++ b/prometheus.yaml
@@ -3,7 +3,8 @@ global:
   scrape_interval:     15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
   evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
   # scrape_timeout is set to the global default (10s).
-
+  external_labels:
+    datacenter: primary
 # Alertmanager configuration
 alerting:
   alertmanagers:
@@ -23,7 +24,19 @@ scrape_configs:
   - job_name: 'prometheus'
     static_configs:
     - targets: ['localhost:9090']
-  
+
+  - job_name: 'federation'
+    scrape_interval: 20s
+    scrape_timeout: 20s
+    scheme: http
+    metrics_path: /federate
+    honor_labels: true
+    params:
+      match[]:
+        - '{job=~"kube-state-metrics|kubernetes-cadvisor"}'
+    static_configs:
+      - targets: ['192.168.1.34:9090']
+
   - job_name: 'node-exporter'
     static_configs:
     - targets: ['172.31.17.121:9100','172.31.28.19:9100','172.31.25.240:9100']
@@ -36,6 +49,7 @@ scrape_configs:
         regex: 'k8s.(.*)'
         target_label: nodename
         replacement: appz-${1}
+
   - job_name: 'kube-state-metrics'
     static_configs:
     - targets: ['kube-state-metrics.kube-system.svc.cluster.local:8080']


### PR DESCRIPTION
- need to update secondary prom target in prometheus yaml
- deploy secondary prometheus with 2927/secondarypromfed branch and use the endpoint as target